### PR TITLE
Update Readme + Memory for chat 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# IDE
+.vscode/

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This section is to talk about the different options we have to give answers to t
 
 ### Description
 
-Used Agent is: `hwchase17/react`. This is used as prompt to generate a response to the user's input. React agents are designed to generate responses to user inputs in a conversational manner. The agent is using the OpenAI API to generate the response. It is currently using the `gpt-3.5-turbo-0125` model, which is the cheapest model available in the OpenAI API.
+Used Agent is: `"hwchase17/structured-chat-agent"`. The structured chat agent is a simple chatbot that can answer questions about structured data. The agent is using the OpenAI API to generate the response. It is currently using the `gpt-3.5-turbo-0125` model, which is the cheapest model available in the OpenAI API.
 
 ### How to run the code locally
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-## Real Estate - Group assignment
+# Real Estate - Group assignment
+
 
 ### Datasets
 * Historical Data: [Historical Housing Data](https://www.car.org/en/marketdata/data/housingdata) 
@@ -27,9 +28,34 @@ This section is to talk about the different options we have to give answers to t
 
 #### Dataset
 
-#### Libraries
+## Agent
+
+### Description
+
+Used Agent is: `hwchase17/react`. This is used as prompt to generate a response to the user's input. React agents are designed to generate responses to user inputs in a conversational manner. The agent is using the OpenAI API to generate the response. It is currently using the `gpt-3.5-turbo-0125` model, which is the cheapest model available in the OpenAI API.
+
+### How to run the code locally
+
+Configure the Python environment with the following environment variables and requirements:
+1. Create `.env` file with the following content:
+
+```
+OPENAI_API_KEY=<YOUR_API_KEY>
+```
+
+2. Install the requirements
+
+```
+pip install -r requirements.txt
+```
+
+### Run the code
+
+```
+chainlit run app.py
+```
+
+## Libraries
 * https://github.com/Bunsly/HomeHarvest
 * https://pypi.org/project/langchain-openai/
 * https://chainlit.io/
-
-#### Flow

--- a/agent/tool.py
+++ b/agent/tool.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from typing import Type, Optional, Literal
 from string import Template
 from pandas import DataFrame
@@ -32,11 +33,18 @@ def expand_row(property: DataFrame) -> str:
     return template.substitute(property.to_dict())
 
 
+class ListingType(Enum):
+    SOLD = "SOLD"
+    FOR_SALE = "FOR_SALE"
+    FOR_RENT = "FOR_RENT"
+    PENDING = "PENDING"
+
 class HomeSearchResultsInput(BaseModel):
     """Input for home search library"""
 
     location: str = Field(description="house location to search")
-    listing_type: Literal["SOLD", "FOR_SALE", "FOR_RENT", "PENDING"] = Field(
+    listing_type: ListingType = Field(
+        default=ListingType.FOR_SALE,
         description="type of listing"
     )
     radius: Optional[float] = None
@@ -55,7 +63,7 @@ class HomeSearchResultsTool(BaseTool):
     def _run(
         self,
         location: str,
-        listing_type: Literal["SOLD", "FOR_SALE", "FOR_RENT", "PENDING"],
+        listing_type: Optional[Literal["SOLD", "FOR_SALE", "FOR_RENT", "PENDING"]] = "FOR_SALE",
         radius: Optional[float] = None,
         run_manager: Optional[CallbackManagerForToolRun] = None,
     ) -> str:

--- a/agent/tool.py
+++ b/agent/tool.py
@@ -63,18 +63,23 @@ class HomeSearchResultsTool(BaseTool):
     def _run(
         self,
         location: str,
-        listing_type: Optional[Literal["SOLD", "FOR_SALE", "FOR_RENT", "PENDING"]] = "FOR_SALE",
+        listing_type: Optional[ListingType] = "FOR_SALE",
         radius: Optional[float] = None,
         run_manager: Optional[CallbackManagerForToolRun] = None,
     ) -> str:
-        properties = scrape_property(
-            location=location,
-            listing_type=listing_type,
-            radius=radius
-        )
+        try:
+            properties = scrape_property(
+                location=location,
+                listing_type=listing_type.value,
+                radius=radius
+            )
+            
+            print(properties)
 
-        properties_expanded = []
-        for _, row in properties.iloc[0:self.max_results].iterrows():
-            properties_expanded.append(expand_row(row))
-        
+            properties_expanded = []
+            for _, row in properties.iloc[0:self.max_results].iterrows():
+                properties_expanded.append(expand_row(row))
+        except Exception as e:
+            return str(e)
+            
         return "\n".join(properties_expanded)

--- a/app.py
+++ b/app.py
@@ -6,6 +6,7 @@ from langchain import hub
 from langchain.schema import StrOutputParser
 from langchain.schema.runnable import Runnable
 from langchain.schema.runnable.config import RunnableConfig
+from langchain.chains.conversation.memory import ConversationBufferWindowMemory
 from langchain_core.runnables.passthrough import RunnablePassthrough
 from langchain.agents import AgentExecutor, create_react_agent
 
@@ -16,8 +17,16 @@ from agent.tool import HomeSearchResultsTool
 load_dotenv()
 openai_api_key = os.getenv("OPENAI_API_KEY")
 
+# # Setting up conversational memory
+# conversational_memory = ConversationBufferWindowMemory(
+#     memory_key='chat_history',
+#     k=5,
+#     return_messages=True
+# )
+
 tools = [HomeSearchResultsTool(max_results=5)]
-prompt = prompt = hub.pull("hwchase17/react")
+# prompt = prompt = hub.pull("hwchase17/react-chat") 
+prompt = hub.pull("hwchase17/react") 
 
 @cl.on_chat_start
 async def on_chat_start():

--- a/app.py
+++ b/app.py
@@ -8,7 +8,7 @@ from langchain.schema.runnable import Runnable
 from langchain.schema.runnable.config import RunnableConfig
 from langchain.chains.conversation.memory import ConversationBufferWindowMemory
 from langchain_core.runnables.passthrough import RunnablePassthrough
-from langchain.agents import AgentExecutor, create_react_agent
+from langchain.agents import AgentExecutor, create_structured_chat_agent
 
 from langchain_openai import ChatOpenAI
 
@@ -26,13 +26,13 @@ openai_api_key = os.getenv("OPENAI_API_KEY")
 
 tools = [HomeSearchResultsTool(max_results=5)]
 # prompt = prompt = hub.pull("hwchase17/react-chat") 
-prompt = hub.pull("hwchase17/react") 
+prompt = hub.pull("hwchase17/structured-chat-agent") 
 
 @cl.on_chat_start
 async def on_chat_start():
     model = ChatOpenAI(model="gpt-3.5-turbo-0125", temperature=0, streaming=True)    
-    agent = create_react_agent(model, tools, prompt)
-    agent_executor = AgentExecutor(agent=agent, tools=tools, verbose=True)
+    agent = create_structured_chat_agent(model, tools, prompt)
+    agent_executor = AgentExecutor(agent=agent, tools=tools, verbose=True, handle_parsing_errors=True)
 
     cl.user_session.set("agent_executor", agent_executor)
 
@@ -42,6 +42,6 @@ async def on_message(message: cl.Message):
     agent_executor = cl.user_session.get("agent_executor")
     
     response = agent_executor.invoke({"input": message.content})
-    msg = cl.Message(content=response)
+    msg = cl.Message(content=response["output"])
 
     await msg.send()

--- a/app.py
+++ b/app.py
@@ -17,22 +17,21 @@ from agent.tool import HomeSearchResultsTool
 load_dotenv()
 openai_api_key = os.getenv("OPENAI_API_KEY")
 
-# # Setting up conversational memory
-# conversational_memory = ConversationBufferWindowMemory(
-#     memory_key='chat_history',
-#     k=5,
-#     return_messages=True
-# )
+# Setting up conversational memory
+conversational_memory = ConversationBufferWindowMemory(
+    memory_key='chat_history',
+    k=5,
+    return_messages=True
+)
 
 tools = [HomeSearchResultsTool(max_results=5)]
-# prompt = prompt = hub.pull("hwchase17/react-chat") 
 prompt = hub.pull("hwchase17/structured-chat-agent") 
 
 @cl.on_chat_start
 async def on_chat_start():
     model = ChatOpenAI(model="gpt-3.5-turbo-0125", temperature=0, streaming=True)    
     agent = create_structured_chat_agent(model, tools, prompt)
-    agent_executor = AgentExecutor(agent=agent, tools=tools, verbose=True, handle_parsing_errors=True)
+    agent_executor = AgentExecutor(agent=agent, tools=tools, verbose=True, handle_parsing_errors=True, memory=conversational_memory)
 
     cl.user_session.set("agent_executor", agent_executor)
 


### PR DESCRIPTION
- Included some details on the Readme about how to run it
- Memory implemented
- Changed literal on Literal_type to be a separated enum. Added `For_sale` as default type for the `HomeSearchResultsInput`.  

The issue I found: chatbot didn't make the parsing on listing_type correctly (it tries to wire it to status) EX:
```
> Entering new AgentExecutor chain...
2024-05-31 21:40:25 - HTTP Request: POST https://api.openai.com/v1/chat/completions "HTTP/1.1 200 OK"
I need to use the home_search_results_tool to find houses for sale in San Mateo, California.
Action: home_search_results_tool
Action Input: location: San Mateo, California, status: FOR_SALE
```
To solve this I changed the prompt to be `hwchase17/structured-chat-agent`, this works better with custom tools that have multiple paramenters. 

